### PR TITLE
pace.min.js | load as a script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+python: "3.6"
+
 services:
   - docker
 install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# VERSION 0.2.9
+
+## Plugins
+
+### Changes
+* Fix rendering of page with "Tables managed by ..."
+
 # VERSION 0.2.8
 
 ## Plugins

--- a/Readme.md
+++ b/Readme.md
@@ -1,8 +1,8 @@
 # DiscreETLy
 
 [![Build Status](https://travis-ci.org/Wikia/discreETLy.svg?branch=master)](https://travis-ci.org/Wikia/discreETLy)
-[![](https://images.microbadger.com/badges/image/fandom/discreetly:0.2.8.svg)](https://microbadger.com/images/fandom/discreetly:0.2.8 "Get your own image badge on microbadger.com")
-[![](https://images.microbadger.com/badges/version/fandom/discreetly:0.2.8.svg)](https://microbadger.com/images/fandom/discreetly:0.2.8 "Get your own version badge on microbadger.com")
+[![](https://images.microbadger.com/badges/image/fandom/discreetly:0.2.9.svg)](https://microbadger.com/images/fandom/discreetly:0.2.9 "Get your own image badge on microbadger.com")
+[![](https://images.microbadger.com/badges/version/fandom/discreetly:0.2.9.svg)](https://microbadger.com/images/fandom/discreetly:0.2.9 "Get your own version badge on microbadger.com")
 
 **DiscreETLy** is an add-on dashboard service on top of [Apache Airflow](https://github.com/apache/incubator-airflow). It is a user friendly UI showing status of particular DAGs. Moreover, it allows the users to map Tasks within a particular DAG to tables available in any system (relational and non-relational) via friendly yaml definition. **DiscreETLy** provides fuctionality for monitoring DAGs status as well as optional communication with services such as [Prometheus](https://prometheus.io/) or [InfluxDB](https://www.influxdata.com/).
 

--- a/dashboard/templates/layouts/base.html
+++ b/dashboard/templates/layouts/base.html
@@ -18,10 +18,11 @@
   <link href="https://cdnjs.cloudflare.com/ajax/libs/simple-line-icons/2.4.1/css/simple-line-icons.css" rel="stylesheet">
   <!-- Main styles for this application-->
   <link rel="stylesheet" href="https://unpkg.com/@coreui/coreui/dist/css/coreui.min.css">
-  <link href="https://cdn.jsdelivr.net/npm/pace-js@1.0.2/pace.min.js" rel="stylesheet">
 
   <!-- base.css -->
   <link rel="stylesheet" href="{{ url_for('static', filename='css/base.css')}}">
+
+  <script src="https://cdn.jsdelivr.net/npm/pace-js@1.0.2/pace.min.js"></script>
 
   <!-- Vega, vega-lite and vega-embedded -->
   <script src="https://cdn.jsdelivr.net/npm/vega@4.2.0"></script>


### PR DESCRIPTION
Refused to apply style from 'https://cdn.jsdelivr.net/npm/pace-js@1.0.2/pace.min.js' because its MIME type ('application/javascript') is not a supported stylesheet MIME type, and strict MIME checking is enabled.

Example: https://data.wikia-services.com/etl/dfp_daily_ad_unit_detail_2.1/2019-03-30%2012:50:00