### PR TITLE
Clarify tables plugin usage - table used in many DAGs, period

### DIFF
--- a/dashboard/model/tables_data.py
+++ b/dashboard/model/tables_data.py
@@ -81,7 +81,8 @@ class TableDataProvider:
     def get_tables_graph(self, dag_id, execution_date):
         name_without_version = clean_dag_id(dag_id)
         dag_tables = self.get_tables_by_dag(name_without_version)
-        dag_progess = {d.task_id: d for d in self.airflow.get_dag_tasks(dag_id, execution_date)}
+        dag_progress = {d.task_id: d for d in self.airflow.get_dag_tasks(dag_id, execution_date)}
+
 
         # root node - dag name
         yield GraphVertex(id='main', name=name_without_version,
@@ -92,10 +93,10 @@ class TableDataProvider:
             yield GraphVertex(
                 id=table.id,
                 name=table.name + (' ({})'.format(table.period.name) if table.period else ''),
-                state=dag_progess[table.task_id].task_state,
+                state=dag_progress[table.task_id].task_state,
                 tooltip='Finished at: {}, duration: {}'.format(
-                    dag_progess[table.task_id].end_date,
-                    dag_progess[table.task_id].duration
+                    dag_progress[table.task_id].end_date,
+                    dag_progress[table.task_id].duration
                 ),
                 parent=table.get_parent()
             )

--- a/dashboard/plugins/tables/README.md
+++ b/dashboard/plugins/tables/README.md
@@ -13,9 +13,19 @@ why a mapping needs to be provided to **discreETLy**. A mapping can be defined i
 - `uses` - a table that provides data for the task populating currently describe table (helps if there are dependencies between tables)
 - `dag_id` - id of a DAG that contains the task required for the mapping
 - `task_id` - id of the task that populates the table
+- (optional) 
 
-
-If several DAGs use the same table, it needs to be redeclared with each `dag_id` for the table to be supported by `Tables managed by DAG` view.  
+Additionally you may want to provide cadence for how often the table is updated like so:  
+```
+  period:
+    id: 1 
+    name: daily
+```
+Update `id` incrementally starting from 1 for each table redeclared with another cadence.  
+This makes specifying dependency on a particular cadence possible, e.g.: `uses: dbname.frequently_updated.daily`.
+  
+If several DAGs use the same table, it needs to be redeclared with each `dag_id` for the table to be supported by 
+ `Tables managed by DAG` view.  
  
 See [example file](tables.yaml.template) for more details on the data structure. 
 

--- a/dashboard/plugins/tables/README.md
+++ b/dashboard/plugins/tables/README.md
@@ -14,6 +14,9 @@ why a mapping needs to be provided to **discreETLy**. A mapping can be defined i
 - `dag_id` - id of a DAG that contains the task required for the mapping
 - `task_id` - id of the task that populates the table
 
+
+If several DAGs use the same table, it needs to be redeclared with each `dag_id` for the table to be supported by `Tables managed by DAG` view.  
+ 
 See [example file](tables.yaml.template) for more details on the data structure. 
 
 The application will automatically ingest the definition of the tables and map them to particular tasks.

--- a/dashboard/plugins/tables/tables.yaml.template
+++ b/dashboard/plugins/tables/tables.yaml.template
@@ -9,14 +9,24 @@
   task_id: fact_table_insert
   uses: dbname.popular_raw_table
 
-- name: rollup_table
+# declaring a table with a specific cadence
+- name: frequently_updated_table
+  db: dbname
+  dag_id: my_dag
+  task_id: update_daily_frequently_updated_table
+  period:
+    id: 1
+    name: daily
+
+- name: rollup_table_daily
   db: dbname
   dag_id: my_dag
   task_id: rollup_table_insert
-  uses: dbname.fact_table
+  uses: dbname.frequently_updated_table.daily
 
 # redeclaring popular_raw_table for use with another DAG
 - name: popular_raw_table
   db: dbname
-  dag_id: another_dag_tha
+  dag_id: another_dag
   task_id: popular_raw_table_sensor
+

--- a/dashboard/plugins/tables/tables.yaml.template
+++ b/dashboard/plugins/tables/tables.yaml.template
@@ -1,16 +1,22 @@
-- name: raw_table
+- name: popular_raw_table
   db: dbname
   dag_id: my_dag
-  task_id: raw_table_insert
+  task_id: popular_raw_table_insert
 
 - name: fact_table
   db: dbname
   dag_id: my_dag
   task_id: fact_table_insert
-  uses: dbname.raw_table
+  uses: dbname.popular_raw_table
 
 - name: rollup_table
   db: dbname
   dag_id: my_dag
   task_id: rollup_table_insert
   uses: dbname.fact_table
+
+# redeclaring popular_raw_table for use with another DAG
+- name: popular_raw_table
+  db: dbname
+  dag_id: another_dag_tha
+  task_id: popular_raw_table_sensor


### PR DESCRIPTION
Clarifies using period declaration and sharing a table between DAGs in the tables plugin.

Fixes found typo in variable name.