### PR TITLE
Issue 22 | Add workaround for table using table from another DAG

### DIFF
--- a/dashboard/model/tables_data.py
+++ b/dashboard/model/tables_data.py
@@ -81,7 +81,8 @@ class TableDataProvider:
     def get_tables_graph(self, dag_id, execution_date):
         name_without_version = clean_dag_id(dag_id)
         dag_tables = self.get_tables_by_dag(name_without_version)
-        dag_progess = {d.task_id: d for d in self.airflow.get_dag_tasks(dag_id, execution_date)}
+        dag_progress = {d.task_id: d for d in self.airflow.get_dag_tasks(dag_id, execution_date)}
+
 
         # root node - dag name
         yield GraphVertex(id='main', name=name_without_version,
@@ -92,10 +93,10 @@ class TableDataProvider:
             yield GraphVertex(
                 id=table.id,
                 name=table.name + (' ({})'.format(table.period.name) if table.period else ''),
-                state=dag_progess[table.task_id].task_state,
+                state=dag_progress[table.task_id].task_state,
                 tooltip='Finished at: {}, duration: {}'.format(
-                    dag_progess[table.task_id].end_date,
-                    dag_progess[table.task_id].duration
+                    dag_progress[table.task_id].end_date,
+                    dag_progress[table.task_id].duration
                 ),
                 parent=table.get_parent()
             )

--- a/dashboard/model/tables_data.py
+++ b/dashboard/model/tables_data.py
@@ -98,7 +98,7 @@ class TableDataProvider:
                     dag_progress[table.task_id].end_date,
                     dag_progress[table.task_id].duration
                 ),
-                # workaround for table.uses not being able to reference table managed by other DAG
+                # workaround for this entire method not being able to reference table managed by other DAG in table.uses
                 # see https://github.com/Wikia/discreETLy/issues/22
                 parent='main' if table.uses is None or table.uses not in dag_tables.keys() else table.uses
             )

--- a/dashboard/plugins/tables/README.md
+++ b/dashboard/plugins/tables/README.md
@@ -24,8 +24,6 @@ Additionally you may want to provide cadence for how often the table is updated 
 Update `id` incrementally starting from 1 for each table redeclared with another cadence.  
 This makes specifying dependency on a particular cadence possible, e.g.: `uses: dbname.frequently_updated.daily`.
   
-If several DAGs use the same table, it needs to be redeclared with each `dag_id` for the table to be supported by 
- `Tables managed by DAG` view.  
  
 See [example file](tables.yaml.template) for more details on the data structure. 
 

--- a/dashboard/plugins/tables/tables.yaml.template
+++ b/dashboard/plugins/tables/tables.yaml.template
@@ -23,10 +23,3 @@
   dag_id: my_dag
   task_id: rollup_table_insert
   uses: dbname.frequently_updated_table.daily
-
-# redeclaring popular_raw_table for use with another DAG
-- name: popular_raw_table
-  db: dbname
-  dag_id: another_dag
-  task_id: popular_raw_table_sensor
-


### PR DESCRIPTION
This replaces node's parent to link to root, instead of failing to lookup table from another DAG. 
See https://github.com/Wikia/discreETLy/issues/22