### PR TITLE
DE-4337 | Ignore the dag version change while displaying the recent dag statuses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ services:
 install:
   - docker build -t dashboard:tests -f dashboard/tests/Dockerfile .
 script:
-  - docker run --rm dashboard:tests
+  - docker-compose --file dashboard/tests/docker-compose.yml up --abort-on-container-exit && docker-compose --file dashboard/tests/docker-compose.yml down

--- a/Readme.md
+++ b/Readme.md
@@ -100,7 +100,7 @@ docker build -t dashboard:tests -f dashboard/tests/Dockerfile .
 Once the image is build the tests can be preformed by typing
 
 ```bash
-docker run --rm dashboard:tests
+docker-compose --file dashboard/tests/docker-compose.yml up --abort-on-container-exit && docker-compose --file dashboard/tests/docker-compose.yml down
 ```
 
 The output of this command shows a nicely formatted information of number of tests performed and success ratio (all tests are performed by using `pytest` package).

--- a/dashboard/tests/docker-compose.yml
+++ b/dashboard/tests/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.7'
 services:
   mysql:
     image: 'mariadb'
+    container_name: test_db
     environment:
       - MYSQL_ROOT_PASSWORD=test
       - MYSQL_DATABASE=pytest
@@ -17,6 +18,8 @@ services:
       start_period: 10s
   tests:
     image: dashboard:tests
+    environment:
+      - TEST_DB_HOST=test_db
     depends_on:
       - mysql
     volumes:

--- a/dashboard/tests/docker-compose.yml
+++ b/dashboard/tests/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.7'
+services:
+  mysql:
+    image: 'mariadb'
+    environment:
+      - MYSQL_ROOT_PASSWORD=test
+      - MYSQL_DATABASE=pytest
+    ports:
+      - 3306:3306
+    volumes:
+      - type: tmpfs
+        target: /var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
+      timeout: 20s
+      retries: 10
+      start_period: 10s
+  tests:
+    image: dashboard:tests
+    depends_on:
+      - mysql
+    volumes:
+        - type: tmpfs
+          target: /var/run

--- a/dashboard/tests/mocks/airflow.sql
+++ b/dashboard/tests/mocks/airflow.sql
@@ -80,7 +80,12 @@ VALUES(3000, 'inactive_dag_v2.0', '2018-11-12 10:00:00.000', 'success', 'schedul
 INSERT INTO dag_run
 (id, dag_id, execution_date, state, run_id, external_trigger, conf, end_date, start_date)
 VALUES(4000, 'dag_marked_as_success_v2.0', '2019-08-01 01:05:00.000', 'success', 'scheduled__2019-08-01T01:05:00+00:00', 0, NULL, NULL, '2019-08-01 01:05:00.000');
-
+INSERT INTO dag_run
+(id, dag_id, execution_date, state, run_id, external_trigger, conf, end_date, start_date)
+VALUES(5000, 'multiple_versions_v2.2', '2018-11-11 02:15:00.000', 'success', 'scheduled__2018-11-11T01:15:00+00:00', 0, NULL, NULL, '2018-11-12 02:15:03.660');
+INSERT INTO dag_run
+(id, dag_id, execution_date, state, run_id, external_trigger, conf, end_date, start_date)
+VALUES(5001, 'multiple_versions_v2.3', '2018-11-12 02:15:00.000', 'failure', 'scheduled__2018-11-12T01:15:00+00:00', 0, NULL, NULL, '2018-11-13 09:11:05.990');
 
 CREATE TABLE task_instance (
   task_id varchar(250) NOT NULL,

--- a/dashboard/tests/mocks/database.py
+++ b/dashboard/tests/mocks/database.py
@@ -2,6 +2,7 @@ import sqlite3
 from dashboard.service.mysql import MySQLClient
 import logging
 import time
+import os
 
 class SqliteService:
 
@@ -29,8 +30,9 @@ class SqliteService:
 class MysqlService:
 
     def __init__(self):
+        db_host = os.getenv('TEST_DB_HOST')
         configuration = {
-            'AIRFLOW_DB_HOST': 'tests_mysql_1',
+            'AIRFLOW_DB_HOST': db_host,
             'AIRFLOW_USERNAME': 'root',
             'AIRFLOW_PASSWORD': 'test',
             'AIRFLOW_DATABASE': 'pytest'


### PR DESCRIPTION
### Issue

ETL dashboard displays too many icons when a dag has some failing statuses

### Cause

In the code we retrieve dag statuses partitioned by dag_id. The dag_id consists of a human-readable name and the version. When the dags are displayed the version is removed from the dag_id and all dags which have the same name (regardless of the version) are merged into one.

Because we retrieve data for every full dag_id, the dashboard displays the statuses of all versions in addition to the current version.

It affects all dags, not only the failing ones, but a failing dag is more likely to have multiple versions.

### Fix

A regular expression was used to extract the dag name from dag_id when the data is retrieved from the database. The dag name (without version) is used to partition and order the data, so the service does not get redundant results.

### How to test

Run the service locally and check the number of icons displayed next to a dag which version has been modified recently.

### Explanations regarding the selected implementation

1. Why did I update the database?

I used REGEXP_INSTR function which is not available in SQLLite, so I created a docker-compose file which runs a MariaDB instance in addition to the test container.

2. Why did not I use REGEXP_REPLACE?

REGEXP_REPLACE is available in our database, but we cannot use it, because of this bug: https://bugs.mysql.com/bug.php?id=93479 (it does not work correctly in our current database version).