### PR TITLE
Move S3 stats database to /var/run/discreetly directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN apk add --update --no-cache mariadb-connector-c \
      && pip install -r requirements.txt \
      && apk del .build-deps
 
+RUN mkdir /var/run/discreetly
+
 COPY . .
 
 CMD ["sh", "-c", "SECRET_KEY=`cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1` gunicorn --worker-class sync --log-level DEBUG --reload -b 0.0.0.0:8000 --graceful-timeout 5 --workers 2 --access-logfile - 'dashboard.app:create_app()'"]

--- a/dashboard/plugins/s3_usage/refresher.py
+++ b/dashboard/plugins/s3_usage/refresher.py
@@ -10,9 +10,9 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from dashboard.utils import Timer
 
-STATS_DB_PATH = '/var/run/s3_stats.db'
-STATS_DB_TMP_PATH = '/var/run/s3_stats.db.tmp'
-LOCK_PATH = '/var/run/s3_stats.db.lock'
+STATS_DB_PATH = '/var/run/discreetly/s3_stats.db'
+STATS_DB_TMP_PATH = '/var/run/discreetly/s3_stats.db.tmp'
+LOCK_PATH = '/var/run/discreetly/s3_stats.db.lock'
 
 class S3StatsRefresher:
     def __init__(self, logger, params):

--- a/dashboard/tests/Dockerfile
+++ b/dashboard/tests/Dockerfile
@@ -5,13 +5,15 @@ WORKDIR /app
 RUN echo "deb http://ftp.debian.org/debian stretch-backports main libs contrib non-free" > /etc/apt/sources.list.d/backports.list
 RUN apt update && apt upgrade -y
 RUN apt-get -t stretch-backports -y install libsqlite3-0
-RUN pip install pytest moto
+RUN pip install pytest 'moto==1.3.9'
 
 COPY requirements.txt requirements.txt
 
 RUN pip install -r requirements.txt
 
 COPY . .
+
+RUN mkdir /var/run/discreetly
 
 ENV AWS_ACCESS_KEY_ID=dummy
 ENV AWS_SECRET_ACCESS_KEY=dummy

--- a/dashboard/tests/docker-compose.yml
+++ b/dashboard/tests/docker-compose.yml
@@ -24,4 +24,4 @@ services:
       - mysql
     volumes:
         - type: tmpfs
-          target: /var/run
+          target: /var/run/discreetly


### PR DESCRIPTION
### Reason

We want to use a non-root user to run the application. Because of that we must store the database in a directory that can be accessed by the user. Creating a new directory which contains only the database seems to be a better idea than granting write access to the previously used directory which can be accessed by every process running in the container.