### PR TITLE
Using COMPANY_NAME in HTML titles

### DIFF
--- a/dashboard/blueprints/page/templates/500.html
+++ b/dashboard/blueprints/page/templates/500.html
@@ -1,6 +1,6 @@
 {% extends 'layouts/clean.html' %}
 
-{% block title %}data.wikia-services.com - internal server error{% endblock %}
+{% block title %}{{ config['COMPANY_NAME'] }} Data - internal server error{% endblock %}
 
 {% block body %}
 

--- a/dashboard/blueprints/page/templates/index.html
+++ b/dashboard/blueprints/page/templates/index.html
@@ -1,7 +1,7 @@
 {% extends 'layouts/base.html' %}
 {% import 'macros/common.html' as common with context %}
 
-{% block title %}Fandom Data{% endblock %}
+{% block title %}{{ config['COMPANY_NAME'] }} Data{% endblock %}
 
 {% block nav %}
     <li class="breadcrumb-item active"><a href="/">Home</a></li>

--- a/dashboard/blueprints/page/templates/no_config.html
+++ b/dashboard/blueprints/page/templates/no_config.html
@@ -1,6 +1,6 @@
 {% extends 'layouts/base.html' %}
 
-{% block title %}data.wikia-services.com - internal server error{% endblock %}
+{% block title %}{{ config['COMPANY_NAME'] }} Data - internal server error{% endblock %}
 
 {% block nav %}
 


### PR DESCRIPTION
A small layout fix that drops hardcoded "Fandom" and "wikia-services"