### PR TITLE
Fixed classes of CoreUI icons

### DIFF
--- a/dashboard/blueprints/page/templates/etl_dashboard.html
+++ b/dashboard/blueprints/page/templates/etl_dashboard.html
@@ -59,7 +59,7 @@
     <div class="col-4 col-sm-4 col-md-2 col-xl-2">
       <a href="{{ config.AIRFLOW_WEBSERVER_BASE_URL }}/admin/airflow/tree?dag_id={{ etl.dag_id }}" target="_blank"  ><button type="button" class="btn status btn-{{ common.status_button_color(etl.state) }}">
           {% if etl.state == 'running' %}
-            <span class="cui-speedometer"></span>
+            <span class="cil-speedometer"></span>
           {% endif %}
           {% if etl.tables_total %}
             {{ (etl.tasks_completed / etl.tasks_total * 100)|int }}% ({{ etl.tables_completed }} of {{ etl.tables_total }}) </button>

--- a/dashboard/plugins/s3_usage/templates/s3_usage/index.html
+++ b/dashboard/plugins/s3_usage/templates/s3_usage/index.html
@@ -23,19 +23,19 @@
   </div>
   <div class="form-check form-check-inline">
     <input class="form-check-input" type="radio" name="inlineRadioOptions" name="treeOrder" value="size_desc" checked>
-    <label class="form-check-label" for="inlineRadio1">data size <span class="cui-sort-descending" aria-hidden="true"></span></label>
+    <label class="form-check-label" for="inlineRadio1">data size <span class="cil-sort-descending" aria-hidden="true"></span></label>
   </div>
   <div class="form-check form-check-inline">
     <input class="form-check-input" type="radio" name="inlineRadioOptions" name="treeOrder" value="files_desc">
-    <label class="form-check-label" for="inlineRadio2">number of files <span class="cui-sort-descending" aria-hidden="true"></span></label>
+    <label class="form-check-label" for="inlineRadio2">number of files <span class="cil-sort-descending" aria-hidden="true"></span></label>
   </div>
   <div class="form-check form-check-inline">
     <input class="form-check-input" type="radio" name="inlineRadioOptions" name="treeOrder" value="avg_file_size_desc">
-    <label class="form-check-label" for="inlineRadio3">average file size <span class="cui-sort-ascending" aria-hidden="true"></span></label>
+    <label class="form-check-label" for="inlineRadio3">average file size <span class="cil-sort-ascending" aria-hidden="true"></span></label>
   </div>
   <div class="form-check form-check-inline">
     <input class="form-check-input" type="radio" name="inlineRadioOptions" name="treeOrder" value="alphabetically">
-    <label class="form-check-label" for="inlineRadio3">alphabetically <span class="cui-sort-ascending" aria-hidden="true"></span></label>
+    <label class="form-check-label" for="inlineRadio3">alphabetically <span class="cil-sort-ascending" aria-hidden="true"></span></label>
   </div>
 </div>
 <div class="row">

--- a/dashboard/plugins/table_descriptions/templates/table_descriptions/index.html
+++ b/dashboard/plugins/table_descriptions/templates/table_descriptions/index.html
@@ -22,14 +22,14 @@
             </div>
         </div>
         <div id="legend">
-            Legend: <span class="cui-layers" aria-hidden="true"></span> Partition column
+            Legend: <span class="cil-layers" aria-hidden="true"></span> Partition column
         </div>
     </div>
 
     <div id="table-container">
         <div class="row mt-3 table-header">
             <div class="col-3">
-                <span id="all-toggle" class="toggle"><span class="cui-chevron-right" aria-hidden="true"></span></span>
+                <span id="all-toggle" class="toggle"><span class="cil-chevron-right" aria-hidden="true"></span></span>
                 Database | Table name
             </div>
             <div class="col-9">Description</div>
@@ -40,7 +40,7 @@
                     <div class="col-3">
                         <span style="white-space: nowrap;">
                             <span id="toggle-{{ table_name }}" class="toggle row-toggle">
-                                <span class="cui-chevron-right" aria-hidden="true"></span>
+                                <span class="cil-chevron-right" aria-hidden="true"></span>
                             </span>
                             {{ table_name }}
                         </span>
@@ -55,7 +55,7 @@
                     </div>
                     {% for column in details.columns %}
                         <div class="row column-data">
-                            <div class="col-3">{{ column.name }} {% if column.is_partition %}<span class="cui-layers" aria-hidden="true"></span>{% endif %}</div>
+                            <div class="col-3">{{ column.name }} {% if column.is_partition %}<span class="cil-layers" aria-hidden="true"></span>{% endif %}</div>
                             <div class="col-3">{{ column.type }}</div>
                             <div class="col-6">{{ column.description }}</div>
                         </div>
@@ -72,8 +72,8 @@
     <script src="{{ url_for('static', filename='js/highlight.js') }}"></script>
     <script src="{{ url_for('static', filename='js/render_vis.js') }}"></script>
     <script>
-        const collapsed_char = '<span class="cui-chevron-right" aria-hidden="true"></span>';
-        const expanded_char = '<span class="cui-chevron-bottom" aria-hidden="true"></span>';
+        const collapsed_char = '<span class="cil-chevron-right" aria-hidden="true"></span>';
+        const expanded_char = '<span class="cil-chevron-bottom" aria-hidden="true"></span>';
 
 
         expand_all = function () {

--- a/dashboard/plugins/tables/templates/tables/index.html
+++ b/dashboard/plugins/tables/templates/tables/index.html
@@ -37,10 +37,10 @@
         {% if 'table_descriptions' in plugins %}</a>{% endif %}
         {% if table.active_alerts %}
             {% for alert in table.active_alerts %}
-                <a href="{{ alert.link }}" target="_blank"><i class="cui-circle-x text-danger" data-toggle="tooltip" data-placement="bottom" title="Alert triggered {{ alert.name}}"></i></a>
+                <a href="{{ alert.link }}" target="_blank"><i class="cil-x-circle text-danger" data-toggle="tooltip" data-placement="bottom" title="Alert triggered {{ alert.name}}"></i></a>
             {% endfor %}
         {% else %}
-            <i class="cui-circle-check text-success" data-toggle="tooltip" data-placement="bottom" title="No active alerts"></i>
+            <i class="cil-check text-success" data-toggle="tooltip" data-placement="bottom" title="No active alerts"></i>
         {% endif %}
     </p>
   </div>

--- a/dashboard/templates/layouts/base.html
+++ b/dashboard/templates/layouts/base.html
@@ -13,7 +13,7 @@
   <title>{% block title %}{% endblock %}</title>
   <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}">
   <!-- Icons-->
-  <link href="https://unpkg.com/@coreui/icons/css/coreui-icons.min.css" rel="stylesheet">
+  <link href="https://unpkg.com/@coreui/icons/css/free.min.css" rel="stylesheet">
   <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
   <link href="https://cdnjs.cloudflare.com/ajax/libs/simple-line-icons/2.4.1/css/simple-line-icons.css" rel="stylesheet">
   <!-- Main styles for this application-->


### PR DESCRIPTION
It looks CoreUI CSS with icons changed and now it uses `cil`, not `cui` prefix (see https://coreui.io/icons/free/)