### PR TITLE
DE-4758 | Allow multiple domains to be used with OAUTH

### DIFF
--- a/config/settings.py.template
+++ b/config/settings.py.template
@@ -39,7 +39,8 @@ DEBUG = not 'PROD' in ENV_VAR_PREFIX
 # Leave this section commented out if you want to ignore OAuth functionality.
 # GOOGLE_CLIENT_ID = os.environ['OAUTH_CLIENT_ID']
 # GOOGLE_CLIENT_SECRET = os.environ['OAUTH_SECRET']
-# Use domain that is used for OAuth services at your comapny, e.g. fandom.com
+# Use domain that is used for OAuth services at your company, e.g. 'fandom.com'
+# You can also use a list ['domain1.com', 'domain2.com']
 # OAUTH_DOMAIN = 
 
 # Application secret

--- a/dashboard/blueprints/page/templates/login.html
+++ b/dashboard/blueprints/page/templates/login.html
@@ -5,8 +5,7 @@
 {% block body %}
 
     <div class="text-center">
-
-        <h3>Login to your {{  config.OAUTH_DOMAIN }} account to access the site</h3>
+        <h3>Login to your {{  config.OAUTH_DOMAIN if config.OAUTH_DOMAIN is string else "/".join(config.OAUTH_DOMAIN)  }} account to access the site</h3>
     <p>
         <a href="{{  url_for('loginpass_google.login') }}"><button class="btn btn-primary">Proceed to Google Authentication</button></a>
     </p>

--- a/dashboard/plugins/s3_usage/README.md
+++ b/dashboard/plugins/s3_usage/README.md
@@ -17,7 +17,7 @@ From the technical perspective: after the application starts, plugin starts `S3S
 that checks for buckets matching the provided regular expression. For each bucket all keys
 are listed and the metadata are stored in aggregated context (in "directory" context) in 
 SQLite database inside Docker container. Tab view uses REST API to retrieve the requested 
-data from SQLite database and presend them in form of the directory tree and subburst
+data from SQLite database and present them in form of the directory tree and subburst
 diagram.
 
 ![s3 usage](screenshot.png)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+werkzeug==0.16.*
 Flask==1.0.*
 Flask-SSLify
 gunicorn==19.9.*


### PR DESCRIPTION
Allows accounts from multiple domains to login to discreETLy - e.g. you may allow users from 'domain1' and 'domain2' to log in.

This is not changing the way current configuration works - if you're using one domain, specifying just a string in `settings.py/OAUTH_DOMAIN` will continue to work.

Also specified werkzeug (Flask dependency) version to <1.0.
This is due to werkzeug's 1.0 release making package structure changes breaking Flask's imports
