### PR TITLE
DE-XXXX | Resolve issue with installing cryptography

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ WORKDIR /app
 
 COPY requirements.txt requirements.txt
 RUN apk add --update --no-cache mariadb-connector-c \
-     && apk add --no-cache --virtual .build-deps mariadb-dev gcc musl-dev gcc build-base libffi-dev \
+     && apk add --no-cache --virtual .build-deps mariadb-dev gcc musl-dev gcc build-base libffi-dev cargo \
+     && pip install --upgrade pip \
      && pip install -r requirements.txt \
      && apk del .build-deps
 


### PR DESCRIPTION
```
#8 52.77   ERROR: Failed building wheel for cryptography
#8 52.77 Successfully built mysqlclient pyyaml MarkupSafe Flask-SSLify
#8 52.77 Failed to build cryptography
#8 52.77 ERROR: Could not build wheels for cryptography which use PEP 517 and cannot be installed directly
```

Docker build wouldn't complete, due to fail when installing `cryptography` package.

It needs Rust's cargo and updated pip to complete.